### PR TITLE
Fix immutable cacing

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -105,19 +105,12 @@ export default (apiUrl, httpClient = fetchJsonWithToken ) => {
         switch (type){
         case GET_LIST:
         case GET_MANY_REFERENCE:
-            if (!headers.has('x-total-count')) {
-                if( json.hasOwnProperty('count')){
-                    // For rest_framework.pagination.LimitOffsetPagination for pagination,
-                    headers.set('x-total-count', json.count);
-                }else{
-                    throw new Error('The X-Total-Count header is missing in the HTTP Response.');
-                }
-            }
             // For rest_framework.pagination.LimitOffsetPagination for pagination,
             const data = json.results || json;
+            const count = parseInt(headers.get('x-total-count') || json.count);
             return {
                 data: data,
-                total: parseInt(headers.get('x-total-count'))
+                total: count
             };
 
         case DELETE:


### PR DESCRIPTION
Do not modify header. Just return the item total count from json, if it is not in the header.

Chrome does not allow us to modify the header by default. I think it is because of the immutable cache feature.