### PR TITLE
GET_LIST array response bug

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -107,7 +107,7 @@ export default (apiUrl, httpClient = fetchJsonWithToken ) => {
         case GET_MANY_REFERENCE:
             // For rest_framework.pagination.LimitOffsetPagination for pagination,
             const data = json.results || json;
-            const count = parseInt(headers.get('x-total-count') || json.count);
+            const count = parseInt(headers.get('x-total-count') || json.count || json.length);
             return {
                 data: data,
                 total: count

--- a/src/test.js
+++ b/src/test.js
@@ -26,8 +26,10 @@ const fakeData = {
     ]
 };
 
+
 global.FormData = require('FormData');
 fetchMock.get(/.*\/api\/users\/\?.*/, {body: fakeData.users, headers: {'x-total-count': 1}});
+fetchMock.get(/.*\/api\/users_no_x_total_count\//, {body: fakeData.users});
 
 // If you use 'rest_framework.pagination.LimitOffsetPagination', it'll return it like this
 fetchMock.get(/.*\/api\/users_drf_paginator\/\?.*/, {body: {
@@ -71,6 +73,7 @@ describe('test get methods', function () {
                 try {
                     expect(response.data[0].id).to.eq(1);
                     expect(response.data.length).to.eq(1);
+                    expect(response.total).to.eq(1);
                     done();
                 } catch( e ) {
                     done( e );
@@ -90,6 +93,27 @@ describe('test get methods', function () {
                 try {
                     expect(response.data[0].id).to.eq(1);
                     expect(response.data.length).to.eq(1);
+                    expect(response.total).to.eq(1);
+                    done();
+                } catch( e ) {
+                    done( e );
+                }
+            },
+            error => console.error(error)
+        );
+    });
+
+    it('should return list of items', function(done){
+        client(GET_LIST, 'users_no_x_total_count',{
+            pagination: {},
+            sort: {},
+            filter: {}
+        }).then(
+            response => {
+                try {
+                    expect(response.data[0].id).to.eq(1);
+                    expect(response.data.length).to.eq(1);
+                    expect(response.total).to.eq(1);
                     done();
                 } catch( e ) {
                     done( e );


### PR DESCRIPTION
Before the response had to have total count either in  x-total-count header or in response object as count attribute. Some of the simple lists do not have pagination, so they have neither. In these cases we just use the array length.